### PR TITLE
python-chardet.inc: update build dependency

### DIFF
--- a/recipes-backport/python/python-chardet.inc
+++ b/recipes-backport/python/python-chardet.inc
@@ -4,5 +4,8 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=a6f89e2100d9b6cdffcea4f398e37343"
 
 inherit pypi
 
+# setup.py of chardet needs this.
+DEPENDS += "${PYTHON_PN}-pytest-runner-native"
+
 SRC_URI[md5sum] = "96e364abdbde20b5f6dbbe2ad9d54d04"
 SRC_URI[sha256sum] = "4f7832e7c583348a9eddd927ee8514b3bf717c061f57b21dbe7697211454d9bb"


### PR DESCRIPTION
Update chardet's build dependency on pytest-runner-native

Signed-off-by: Maxin B. John <maxin.john@intel.com>