### PR TITLE
python-restrictedpython: fix downloading during do_compile

### DIFF
--- a/recipes-devtools/python/python-restrictedpython.inc
+++ b/recipes-devtools/python/python-restrictedpython.inc
@@ -3,6 +3,8 @@ HOMEPAGE = "http://pypi.python.org/pypi/RestrictedPython"
 LICENSE = "ZPL-2.1"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=78ccb3640dc841e1baecb3e27a6966b2"
 
+DEPENDS += "${PYTHON_PN}-pytest-runner-native"
+
 inherit pypi
 
 PYPI_PACKAGE = "RestrictedPython"


### PR DESCRIPTION
During do_compile if setup.py finds that pytest-runner - which is
declared as a setup dependency in setup.py - isn't available it was
attempting to download it from pypi, which is problematic if you are
behind a proxy because the environment for do_compile isn't set up for
that. Add an appropriate native dependency to prevent this situation.

Signed-off-by: Paul Eggleton <paul.eggleton@linux.intel.com>