### PR TITLE
python3-urllib3: add backport for 1.22

### DIFF
--- a/recipes-backport/python/python-urllib3.inc
+++ b/recipes-backport/python/python-urllib3.inc
@@ -1,0 +1,19 @@
+SUMMARY = "Python HTTP library with thread-safe connection pooling, file post support, sanity friendly, and more"
+HOMEPAGE = "https://github.com/shazow/urllib3"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=ea114851ad9a8c311aac8728a681a067"
+
+SRC_URI[md5sum] = "0da7bed3fe94bf7dc59ae37885cc72f7"
+SRC_URI[sha256sum] = "cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
+
+RDEPENDS_${PN} += "\
+    ${PYTHON_PN}-certifi \
+    ${PYTHON_PN}-cryptography \
+    ${PYTHON_PN}-email \
+    ${PYTHON_PN}-idna \
+    ${PYTHON_PN}-netclient \
+    ${PYTHON_PN}-pyopenssl \
+    ${PYTHON_PN}-threading \
+"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-backport/python/python3-urllib3_1.22.bb
+++ b/recipes-backport/python/python3-urllib3_1.22.bb
@@ -1,0 +1,2 @@
+inherit pypi setuptools3
+require python-urllib3.inc


### PR DESCRIPTION
I found a  rountime dependecy module missing