### PR TITLE
Python package 'netrc' was missing

### DIFF
--- a/recipes-devtools/python/python3-aiohttp_3.0.6.bb
+++ b/recipes-devtools/python/python3-aiohttp_3.0.6.bb
@@ -17,4 +17,5 @@ RDEPENDS_${PN} = "\
     ${PYTHON_PN}-multidict \
     ${PYTHON_PN}-yarl \
     ${PYTHON_PN}-attrs \
+    ${PYTHON_PN}-misc \    
     "


### PR DESCRIPTION
When having all our Yocto meta layers at master, the iohttp server was failing because netrc (python3-netrc) was missing.
This was not the case when having all our Yocto layers at Rocko.
It's not fully clear for me why netrc was not installed anymore.

Anyhow, please feel free to merge or to wait for a better solution.